### PR TITLE
 Fix alacritty  error caused by default config calling for non existing file

### DIFF
--- a/config/sway/config
+++ b/config/sway/config
@@ -14,7 +14,7 @@ set $down j
 set $up k
 set $right l
 # Your preferred terminal emulator
-set $term alacritty --config-file /etc/alacritty/alacritty.yml
+set $term alacritty
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.


### PR DESCRIPTION
I don't think a yaml file is needed, clean defaults work fine. This commit is mostly to remove the Red banner with error appearing at the bottom of alacritty window:

![image](https://user-images.githubusercontent.com/44322817/220235517-c1a3d250-cce8-4499-9f14-557bfd5cd252.png)
