### PR TITLE
Make wofi launcher use icons and dark mode

### DIFF
--- a/config/sway/config.d/50-greybeard.conf
+++ b/config/sway/config.d/50-greybeard.conf
@@ -6,8 +6,8 @@
 # distrobox as secondary terminal
 bindsym $mod+Shift+Return exec $$term -e distrobox enter
 
-# wofi as application launcher
-set $menu wofi --show drun,run
+# wofi as application launcher, displaying icons and using dark mode
+set $menu wofi --show drun,run -I -G
 
 # greybeard wallpaper
 output * bg /usr/share/wallpapers/wallpaper.png fill


### PR DESCRIPTION
I think it's better looking to use dark mode for the app launcher and icons are a nice touch. 

