### PR TITLE
Add config to launch first boot wizard when sway starts up

### DIFF
--- a/config/sway/config.d/50-firstboot.conf
+++ b/config/sway/config.d/50-firstboot.conf
@@ -1,0 +1,1 @@
+exec /bin/bash /usr/bin/mod-firstboot


### PR DESCRIPTION
I am  aware that we may drop the scripts using zenity in favour of TUI, jeos installer or simple terminal prompt. However this is an easy setup to launch the script, whatever form we end up picking.

Zenity and other gtk3 apps use light mode and if we want to enable darkmode across the system we need to consider this" 

1) For gtk3 it's easy enough, we could just drop a config file in gtk-3.0/settings.ini with
```
[Settings]
gtk-application-prefer-dark-theme=1
```

2) settings.ini does not work for GTK 4. Darkmode could be set in the sway configs `gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'` however for it to work we need to install relevant packages.