### PR TITLE
Set customized window colors defaults

### DIFF
--- a/config/sway/config.d/50-greybeard.conf
+++ b/config/sway/config.d/50-greybeard.conf
@@ -12,6 +12,10 @@ set $menu wofi --show drun,run -I -G
 # greybeard wallpaper
 output * bg /usr/share/wallpapers/wallpaper.png fill
 
+# window title colors and indicator color
+client.focused "#000000" "#2d3436" "#ffffff" "#fdf6e3" "#000000"
+client.unfocused "#000000" "#4d5051" "#958e8e" "#fdf6e3" "#000000"
+
 # Enable common options for generic touchpads
 input "type:touchpad" {
   tap enabled


### PR DESCRIPTION
Went for a monochrome proposal as we discussed but picked dark grey for the focused window and a medium grey for the unfocused one. The tiling indicator is a light grey.

We can tune the colors if needed.

![image](https://user-images.githubusercontent.com/44322817/221516100-20546c5e-c673-4faa-853d-52ab817b156d.png)
