### PR TITLE
Change default terminal and launcher

### DIFF
--- a/config/sway/config
+++ b/config/sway/config
@@ -14,7 +14,7 @@ set $down j
 set $up k
 set $right l
 # Your preferred terminal emulator
-set $term alacritty
+set $term foot
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.

--- a/config/sway/config.d/50-greybeard.conf
+++ b/config/sway/config.d/50-greybeard.conf
@@ -7,7 +7,11 @@
 bindsym $mod+Shift+Return exec $$term -e distrobox enter
 
 # wofi as application launcher, displaying icons and using dark mode
-set $menu wofi --show drun,run -I -G
+# set $menu wofi --show drun,run -I -G
+
+# set sway-launcher-desktop as launcher
+for_window [app_id="^launcher$"] floating enable, sticky enable, resize set 30 ppt 60 ppt, border pixel 10
+set $menu exec $term -a launcher -e sway-launcher-desktop
 
 # greybeard wallpaper
 output * bg /usr/share/wallpapers/wallpaper.png fill


### PR DESCRIPTION
Foot is a much "lighter" terminal than alacritty, and sway-desktop-launcher is much more flexible, and has less dependencies