### PR TITLE
Rename autostartsway.sh to sway.sh (Bugs !7)

### DIFF
--- a/config/profile.d/autostartsway.sh
+++ b/config/profile.d/autostartsway.sh
@@ -1,3 +1,0 @@
-if [ -z "${DISPLAY}" ] && [ "${XDG_VTNR}" -eq 1 ]; then
-  exec sway
-fi

--- a/config/profile.d/sway.sh
+++ b/config/profile.d/sway.sh
@@ -1,0 +1,3 @@
+if [ -z "${DISPLAY}" ] && [ "${XDG_VTNR}" -eq 1 ]; then
+  exec sway
+fi


### PR DESCRIPTION
autostartsway.sh is wrong. The files should use the same name as the program, and cannot be random. We need to be using sway.sh instead.

https://github.com/ProjectGreybeard/bugs/issues/7