### PR TITLE
Enable dark mode by default for GTK 4 applications (bugs#15)

### DIFF
--- a/config/sway/config.d/50-greybeard.conf
+++ b/config/sway/config.d/50-greybeard.conf
@@ -91,6 +91,7 @@ set $wob wob --config /etc/sway/wob/wob.ini
 
 exec_always {
     systemctl --user import-environment
+    gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
     gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
     gsettings set org.gnome.desktop.interface icon-theme 'Adwaita'
     gsettings set org.gnome.desktop.interface cursor-theme 'Adwaita'


### PR DESCRIPTION
Enable dark mode by default for GTK 4 applications via `gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark`

Fixes: https://github.com/ProjectGreybeard/bugs/issues/15