### PR TITLE
Bind Print (PrtSc) key to grim to take screenshots (ProjectGreybeard/bugs#13)

### DIFF
--- a/config/sway/config.d/50-greybeard.conf
+++ b/config/sway/config.d/50-greybeard.conf
@@ -104,3 +104,7 @@ exec /usr/libexec/polkit-gnome-authentication-agent-1
 
 # Enable Adwaita cursor theme
 seat seat0 xcursor_theme Adwaita 16
+
+# Use PrtSc (Print) key to take a screenshot of the entire screen and save it in $HOME
+bindsym Print exec grim
+


### PR DESCRIPTION
A very simple setup where PrtSc (Print) key is bound to grim. It takes a screenshot of the entire screen and saves it in $HOME.