### PR TITLE
Add configuration for t-u

### DIFF
--- a/config/transactional-update.d/50-desktop.conf
+++ b/config/transactional-update.d/50-desktop.conf
@@ -1,0 +1,1 @@
+REBOOT_METHOD=notify


### PR DESCRIPTION
Adds transactional-update.d/50-desktop.conf, to ensure that t-u keeps notifying users of new snapshots, and not getting overwritten by updates to /usr/etc/transactional-update.conf