### PR TITLE
Bind mouse middle click to close windows (ProjectGreybeard/bugs#21)

### DIFF
--- a/config/sway/config.d/50-greybeard.conf
+++ b/config/sway/config.d/50-greybeard.conf
@@ -108,3 +108,5 @@ seat seat0 xcursor_theme Adwaita 16
 # Use PrtSc (Print) key to take a screenshot of the entire screen and save it in $HOME
 bindsym Print exec grim
 
+# Use mouse middle button click to close windows
+bindsym --border button2 kill


### PR DESCRIPTION
Allows to use mouse or touchpad middle click to close windows. 